### PR TITLE
Remove button to view user drivers license

### DIFF
--- a/includes/view/AngelTypes_view.php
+++ b/includes/view/AngelTypes_view.php
@@ -73,9 +73,6 @@ function AngelType_view($angeltype, $members, $user_angeltype, $admin_user_angel
       button(page_link_to('angeltypes'), _("Angeltypes"), 'back') 
   ];
   
-  if ($angeltype['requires_driver_license'])
-    $buttons[] = button(user_driver_license_edit_link($user), glyph("road") . _("my driving license"));
-  
   if ($user_angeltype == null)
     $buttons[] = button(page_link_to('user_angeltypes') . '&action=add&angeltype_id=' . $angeltype['id'], _("join"), 'add');
   else {

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -222,7 +222,6 @@ function User_view($user_source, $admin_user_privilege, $freeloader, $user_angel
           div('col-md-12', array(
               buttons(array(
                   $admin_user_privilege ? button(page_link_to('admin_user') . '&id=' . $user_source['UID'], glyph("edit") . _("edit")) : '',
-                  $admin_user_privilege ? button(user_driver_license_edit_link($user_source), glyph("road") . _("driving license")) : '',
                   ($admin_user_privilege && ! $user_source['Gekommen']) ? button(page_link_to('admin_arrive') . '&arrived=' . $user_source['UID'], _("arrived")) : '',
                   $admin_user_privilege ? button(page_link_to('users') . '&action=edit_vouchers&user_id=' . $user_source['UID'], glyph('cutlery') . _('Edit vouchers')) : '',
                   $its_me ? button(page_link_to('user_settings'), glyph('list-alt') . _("Settings")) : '',


### PR DESCRIPTION
Since user drivers license feature is not needed for KIF, this PR removes all the buttons to get to its pages.
